### PR TITLE
Cache Busting

### DIFF
--- a/assets/js/microp.js
+++ b/assets/js/microp.js
@@ -17,10 +17,11 @@ jQuery(document).ready(function($) {
 			if (response.status == 'ok') {
 				var newImage = new Image();
 				newImage.src = response.file + '?' + Math.random();
+				var originalImageSrc = response.original_file;
 				var count = 0;
 				function updateImage() {
 				    if(newImage.complete) {
-				        $('img[src^="' + response.file + '"]').attr('src', newImage.src);
+				        $('img[src^="' + originalImageSrc + '"]').attr('src', newImage.src);
 						$('#micCropImage').show();
 						$('#micSuccessMessage').show().delay(5000).fadeOut();
 						$('#micLoading').hide();


### PR DESCRIPTION
Updated to use same image renaming logic as default WP editor to cache bust images.